### PR TITLE
Fix Flask static file serving to use absolute frontend directory

### DIFF
--- a/backend/backend.py
+++ b/backend/backend.py
@@ -12,6 +12,8 @@ CORS(app) # Habilita CORS para permitir solicitudes desde el frontend
 # os.path.dirname() obtiene el directorio de ese script
 # os.path.join() une el directorio con el nombre del archivo
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+# Directorio que contiene los archivos HTML/estáticos del frontend (calculador.html vive en la raíz del repo)
+FRONTEND_DIR = os.path.abspath(os.path.join(BASE_DIR, os.pardir))
 EXCEL_FILE_PATH = os.path.join(BASE_DIR, 'Calculador Solar - web 06-24_con ayuda - modificaciones 2025_5.xlsx')
 
 # --- NUEVA RUTA: Para obtener la lista de electrodomésticos y sus consumos ---
@@ -152,12 +154,12 @@ def generar_informe():
 # Opcional: Rutas para servir los archivos estáticos de tu frontend
 @app.route('/')
 def serve_calculador_html():
-    return send_from_directory('.', 'calculador.html')
+    return send_from_directory(FRONTEND_DIR, 'calculador.html')
 
 @app.route('/<path:path>')
 def serve_static_files(path):
-    # Asegúrate de que los archivos estén en la misma carpeta que 'backend.py'
-    return send_from_directory('.', path)
+    # Los archivos estáticos viven junto a calculador.html (en la raíz del repositorio)
+    return send_from_directory(FRONTEND_DIR, path)
 
 if __name__ == '__main__':
     app.run(debug=True)


### PR DESCRIPTION
## Summary
- define an absolute FRONTEND_DIR that points to the repository root where calculador.html and static assets live
- serve calculador.html and other static files using send_from_directory with the explicit FRONTEND_DIR

## Testing
- python backend/backend.py (manual)
- curl -i http://127.0.0.1:5000/
- curl -I http://127.0.0.1:5000/calculador.js

------
https://chatgpt.com/codex/tasks/task_e_68d1ab9e974c83278587de45be0e019a