### PR TITLE
Add status API endpoint and frontend status fetch

### DIFF
--- a/backend/backend.py
+++ b/backend/backend.py
@@ -7,6 +7,11 @@ import os
 app = Flask(__name__)
 CORS(app) # Habilita CORS para permitir solicitudes desde el frontend
 
+# Endpoint simple para comprobar el estado del backend
+@app.route('/api/status', methods=['GET'])
+def api_status():
+    return jsonify({"message": "Backend operativo"})
+
 # Construir la ruta absoluta al archivo Excel
 # __file__ es la ruta al script actual (backend.py)
 # os.path.dirname() obtiene el directorio de ese script

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -4,10 +4,28 @@ function App() {
   const [message, setMessage] = useState('Cargando...')
 
   useEffect(() => {
-    fetch('http://localhost:5000/')
-      .then(res => res.json())
-      .then(data => setMessage(data.message))
-      .catch(() => setMessage('Error al conectar con el backend'))
+    const fetchStatus = async () => {
+      try {
+        const response = await fetch('http://localhost:5000/api/status')
+
+        if (!response.ok) {
+          throw new Error(`Respuesta inesperada: ${response.status}`)
+        }
+
+        const data = await response.json()
+
+        if (data && typeof data.message === 'string') {
+          setMessage(data.message)
+        } else {
+          setMessage('Respuesta del backend inválida')
+        }
+      } catch (error) {
+        console.error('Error al obtener el estado del backend:', error)
+        setMessage('Error al conectar con el backend')
+      }
+    }
+
+    fetchStatus()
   }, [])
 
   return (


### PR DESCRIPTION
## Summary
- add a `/api/status` endpoint that returns a simple JSON health message
- update the React app to call the new endpoint and surface success or error states

## Testing
- curl -s http://127.0.0.1:5000/api/status
- Manual verification of the React dev server while the backend was running

------
https://chatgpt.com/codex/tasks/task_e_68d1abaa8f48832793eaf3ed6564cea8