### PR TITLE
Use configurable API base URL in frontend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ dist/
 # General
 .env
 *.log
+!frontend/.env

--- a/frontend/.env
+++ b/frontend/.env
@@ -1,0 +1,1 @@
+VITE_API_BASE_URL=/api

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -6,7 +6,12 @@ function App() {
   useEffect(() => {
     const fetchStatus = async () => {
       try {
-        const response = await fetch('http://localhost:5000/api/status')
+        const baseUrl = import.meta.env.VITE_API_BASE_URL || '/api'
+        const endpoint = baseUrl.endsWith('/')
+          ? `${baseUrl}status`
+          : `${baseUrl}/status`
+
+        const response = await fetch(endpoint)
 
         if (!response.ok) {
           throw new Error(`Respuesta inesperada: ${response.status}`)


### PR DESCRIPTION
## Summary
- update the frontend status request to derive its endpoint from `VITE_API_BASE_URL`
- add a frontend `.env` file that sets the default API base path to `/api`
- allow the tracked `.env` file for the frontend to be committed

## Testing
- npm run build


------
https://chatgpt.com/codex/tasks/task_e_68d1ae7941ac832794d5e1e4384fdcb4