### PR TITLE
Configura URL base del API con fallbacks por entorno

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -6,7 +6,9 @@ function App() {
   useEffect(() => {
     const fetchStatus = async () => {
       try {
-        const baseUrl = import.meta.env.VITE_API_BASE_URL || '/api'
+        const baseUrl =
+          import.meta.env.VITE_API_BASE_URL ??
+          (import.meta.env.DEV ? 'http://localhost:5000/api' : '/api')
         const endpoint = baseUrl.endsWith('/')
           ? `${baseUrl}status`
           : `${baseUrl}/status`


### PR DESCRIPTION
## Summary
- configura la URL base del backend para usar VITE_API_BASE_URL cuando esté disponible y establecer valores por defecto para desarrollo y producción

## Testing
- npm run dev -- --host 0.0.0.0 --port 5173 --clearScreen false

------
https://chatgpt.com/codex/tasks/task_e_68d1b05c50088327a9872e6dcee28b0e